### PR TITLE
feat: 세션 종류 후 30분 뒤 재진입하면 기분 상태 초기화 기능 추가

### DIFF
--- a/apps/web/src/hooks/useMoodExpiry.ts
+++ b/apps/web/src/hooks/useMoodExpiry.ts
@@ -1,0 +1,150 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+
+import {
+  MOOD_EXPIRY_DURATION_MS,
+  useMoodStore,
+} from '@/stores/moodStore';
+
+interface UseMoodExpiryOptions {
+  /** 만료 시 호출되는 콜백 */
+  onExpire?: () => void;
+  /** 사용자 활동에 따라 만료 시간을 자동 연장할지 여부 */
+  autoRefresh?: boolean;
+  /** 연속 활동 시 만료 연장 최소 간격 */
+  refreshThrottleMs?: number;
+}
+
+const DEFAULT_ACTIVITY_EVENTS: Array<keyof WindowEventMap> = [
+  'keydown',
+  'mousemove',
+  'pointerdown',
+  'touchstart',
+];
+
+const DEFAULT_REFRESH_THROTTLE_MS = 60 * 1000;
+
+export function useMoodExpiry({
+  autoRefresh = false,
+  onExpire,
+  refreshThrottleMs = DEFAULT_REFRESH_THROTTLE_MS,
+}: UseMoodExpiryOptions = {}) {
+  const mood = useMoodStore(state => state.mood);
+  const expiresAt = useMoodStore(state => state.expiresAt);
+  const ensureMoodValidity = useMoodStore(state => state.ensureMoodValidity);
+  const refreshExpiry = useMoodStore(state => state.refreshExpiry);
+  const hasExpired = useMoodStore(state => state.hasExpired);
+
+  const onExpireRef = useRef(onExpire);
+  useEffect(() => {
+    onExpireRef.current = onExpire;
+  }, [onExpire]);
+
+  const triggerExpire = useCallback(() => {
+    const isStillValid = ensureMoodValidity();
+    if (!isStillValid) {
+      onExpireRef.current?.();
+    }
+  }, [ensureMoodValidity]);
+
+  // 초기 렌더 시 만료 여부 확인
+  useEffect(() => {
+    if (!mood) {
+      return;
+    }
+
+    if (!ensureMoodValidity()) {
+      onExpireRef.current?.();
+    }
+  }, [ensureMoodValidity, mood]);
+
+  // 만료 타이머 등록
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    if (!mood || !expiresAt) {
+      return;
+    }
+
+    const now = Date.now();
+    const remainingMs = expiresAt - now;
+
+    if (remainingMs <= 0) {
+      triggerExpire();
+      return;
+    }
+
+    const timerId = window.setTimeout(() => {
+      triggerExpire();
+    }, remainingMs);
+
+    return () => {
+      window.clearTimeout(timerId);
+    };
+  }, [expiresAt, mood, triggerExpire]);
+
+  // 사용자 활동 감지 시 만료 시간 연장
+  useEffect(() => {
+    if (!autoRefresh) {
+      return;
+    }
+
+    if (typeof window === 'undefined' || typeof document === 'undefined') {
+      return;
+    }
+
+    if (!mood) {
+      return;
+    }
+
+    let lastRefreshed = 0;
+
+    const maybeRefresh = () => {
+      const now = Date.now();
+      if (now - lastRefreshed < refreshThrottleMs) {
+        return;
+      }
+
+      lastRefreshed = now;
+      refreshExpiry(MOOD_EXPIRY_DURATION_MS);
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        maybeRefresh();
+      }
+    };
+
+    DEFAULT_ACTIVITY_EVENTS.forEach(eventName => {
+      window.addEventListener(eventName, maybeRefresh, { passive: true });
+    });
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      DEFAULT_ACTIVITY_EVENTS.forEach(eventName => {
+        window.removeEventListener(eventName, maybeRefresh);
+      });
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, [autoRefresh, mood, refreshExpiry, refreshThrottleMs]);
+
+  const remainingMs = useMemo(() => {
+    if (!expiresAt) {
+      return null;
+    }
+
+    return Math.max(0, expiresAt - Date.now());
+  }, [expiresAt]);
+
+  const isExpired = mood ? hasExpired() : false;
+
+  return {
+    expiresAt,
+    isExpired,
+    mood,
+    remainingMs,
+  };
+}

--- a/apps/web/src/stores/moodStore.ts
+++ b/apps/web/src/stores/moodStore.ts
@@ -5,6 +5,8 @@ import { devtools, persist } from 'zustand/middleware';
 
 import type { MoodType } from '@/components/EmotionState';
 
+export const MOOD_EXPIRY_DURATION_MS = 30 * 60 * 1000;
+
 /**
  * 기분/컨디션 스토어 상태
  */
@@ -13,22 +15,38 @@ interface MoodState {
   mood: MoodType | null;
   /** 현재 사용자 ID (세션 추적용) */
   userId: string | null;
+  /** 기분 선택 만료 시각 (epoch ms) */
+  expiresAt: number | null;
+  /** 레시피 추천 결과 페이지 진입 여부 */
+  isRecommendationReady: boolean;
 }
 
 /**
  * 기분/컨디션 스토어 액션
  */
 interface MoodActions {
-  /** 기분 설정 */
+  /** 온보딩 등에서 사용하는 기본 기분 설정 */
   setMood: (mood: MoodType | null) => void;
+  /** 메인 페이지 전용 만료시간 포함 기분 설정 */
+  setMoodWithExpiry: (mood: MoodType | null, durationMs?: number) => void;
+  /** 만료 시간 연장 */
+  refreshExpiry: (durationMs?: number) => void;
+  /** 추천 결과 진입 상태 갱신 */
+  markRecommendationReady: (isReady: boolean) => void;
   /** 기분 초기화 */
   clearMood: () => void;
+  /** 기분 만료 여부 */
+  hasExpired: () => boolean;
+  /** 만료 시 초기화 수행 */
+  ensureMoodValidity: () => boolean;
   /** 사용자 세션 검증 및 필요시 초기화 */
   validateUserSession: (currentUserId: string | null) => void;
 }
 
 /** 초기 상태 */
 const initialState: MoodState = {
+  expiresAt: null,
+  isRecommendationReady: false,
   mood: null,
   userId: null,
 };
@@ -41,6 +59,7 @@ const initialState: MoodState = {
  * - 온보딩 및 다른 페이지에서 재사용 가능
  * - localStorage에 자동 저장 (persist)
  * - 사용자 세션 변경 시 자동 초기화
+ * - 메인 페이지에서 30분 만료 로직 관리
  */
 export const useMoodStore = create<MoodState & MoodActions>()(
   devtools(
@@ -51,11 +70,116 @@ export const useMoodStore = create<MoodState & MoodActions>()(
 
         // 액션들
         clearMood: () => {
-          set({ mood: null }, false, 'clearMood');
+          set(
+            {
+              expiresAt: null,
+              isRecommendationReady: false,
+              mood: null,
+            },
+            false,
+            'clearMood'
+          );
+        },
+
+        ensureMoodValidity: () => {
+          const state = get();
+
+          if (!state.mood) {
+            // mood가 비어있으면 만료 상태로 보지 않음
+            return true;
+          }
+
+          if (!state.expiresAt) {
+            // 만료 시간이 없다면 아직 만료 설정이 되지 않은 상태
+            return true;
+          }
+
+          if (state.expiresAt > Date.now()) {
+            return true;
+          }
+
+          console.info('⏰ 기분 선택 만료 감지, 상태 초기화');
+          set(
+            {
+              expiresAt: null,
+              isRecommendationReady: false,
+              mood: null,
+            },
+            false,
+            'expireMood'
+          );
+          return false;
+        },
+
+        hasExpired: () => {
+          const { expiresAt } = get();
+          if (expiresAt == null) {
+            return false;
+          }
+          return expiresAt <= Date.now();
+        },
+
+        markRecommendationReady: (isReady: boolean) => {
+          set(
+            { isRecommendationReady: isReady },
+            false,
+            'markRecommendationReady'
+          );
+        },
+
+        refreshExpiry: (durationMs = MOOD_EXPIRY_DURATION_MS) => {
+          const state = get();
+          if (!state.mood) {
+            return;
+          }
+
+          const nextExpiry = Date.now() + durationMs;
+          set({ expiresAt: nextExpiry }, false, 'refreshExpiry');
         },
 
         setMood: (mood: MoodType | null) => {
-          set({ mood }, false, 'setMood');
+          const normalizedMood = mood && mood !== 'default' ? mood : null;
+          set(
+            {
+              expiresAt: null,
+              isRecommendationReady: false,
+              mood: normalizedMood,
+            },
+            false,
+            'setMood'
+          );
+        },
+
+        setMoodWithExpiry: (
+          mood: MoodType | null,
+          durationMs = MOOD_EXPIRY_DURATION_MS
+        ) => {
+          const normalizedMood = mood && mood !== 'default' ? mood : null;
+
+          if (!normalizedMood) {
+            set(
+              {
+                expiresAt: null,
+                isRecommendationReady: false,
+                mood: null,
+              },
+              false,
+              'setMoodWithExpiry-clear'
+            );
+            return;
+          }
+
+          const nextExpiry = Date.now() + durationMs;
+
+          set(
+            {
+              expiresAt: nextExpiry,
+              isRecommendationReady: false,
+              mood: normalizedMood,
+            },
+            false,
+            'setMoodWithExpiry'
+          );
         },
 
         validateUserSession: (currentUserId: string | null) => {
@@ -68,7 +192,11 @@ export const useMoodStore = create<MoodState & MoodActions>()(
 
           if (userId !== currentUserId) {
             console.info('🔄 사용자 세션 변경 감지, 기분 데이터 초기화');
-            set({ ...initialState, userId: currentUserId }, false, 'resetSession');
+            set(
+              { ...initialState, userId: currentUserId },
+              false,
+              'resetSession'
+            );
           }
         },
       }),


### PR DESCRIPTION
## 📋 변경 사항

### 작업 유형

- [x] ✨ 새로운 기능 추가
- [ ] 🐛 버그 수정
- [ ] ♻️ 리팩토링
- [ ] 📝 문서 업데이트
- [ ] 🎨 UI/UX 개선
- [ ] 🔧 설정 변경

### 담당 도메인

- [ ] 👤 인증 & 설문
- [x] 🏠 메인 & 재료입력
- [ ] 👨‍🍳 레시피 & 요리
- [ ] ⚙️ 마이페이지 & UI

## 🎯 주요 변경 내용

<!-- 이 PR에서 어떤 변경이 있었는지 간단히 설명해주세요 -->
- 세션 종류 후 30분 이후 기분상태 초기화(어떤 url로 접근하든 메인으로 리다이렉트)
- 세션 종료 후 30분 이내 재접속 시 추천결과화면 유지
- 세션 유지 시 초기화 제한 없음
> 아직 테스트 미완료 입니다 dev에서 추가 테스트가 필요합니다.

## ✅ 테스트 완료

- [ ] 로컬 환경에서 정상 작동 확인
- [ ] 주요 브라우저 테스트 (Chrome, Safari)
- [ ] ESLint & TypeScript 에러 없음

## 📸 스크린샷 (UI 변경시)

<!-- 변경된 UI가 있다면 스크린샷을 첨부해주세요 -->

## 🔍 리뷰 포인트

<!-- 리뷰어가 특별히 확인해야 할 사항이나 고민되는 부분을 작성해주세요 (선택사항) -->

## 📚 관련 정보

- **관련 이슈**: close #
- **디자인 링크**:

---

**🎉 코드 리뷰 부탁드립니다!**
